### PR TITLE
Configure XStream security feature && define only needed converters

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugins/hadolint/model/XmlHandler.java
+++ b/src/main/java/fr/cnes/sonar/plugins/hadolint/model/XmlHandler.java
@@ -18,7 +18,15 @@ package fr.cnes.sonar.plugins.hadolint.model;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.mapper.MapperWrapper;
+import com.thoughtworks.xstream.security.NoTypePermission;
+import com.thoughtworks.xstream.security.NullPermission;
+import com.thoughtworks.xstream.security.PrimitiveTypePermission;
+import com.thoughtworks.xstream.converters.basic.NullConverter;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.converters.reflection.ReflectionConverter;
 import java.io.InputStream;
+import java.util.Collection;
 
 /**
  * Class used to unmarshal ShellCheck xml file (results and rules definition).
@@ -53,8 +61,31 @@ public class XmlHandler {
                     }
                 };
             }
+            // only register the converters we need
+            // other converters generate a private access warning in the console on Java9+...
+            @Override
+            protected void setupConverters() {
+                registerConverter(new NullConverter(), PRIORITY_VERY_HIGH);
+                registerConverter(new StringConverter(), PRIORITY_NORMAL);
+                registerConverter(new CollectionConverter(getMapper()), PRIORITY_NORMAL);
+                registerConverter(new ReflectionConverter(getMapper(), getReflectionProvider()), PRIORITY_VERY_LOW);
+            }
         };
+
+        // Configure XStream security feature to avoid warnings
+        // clear out existing permissions and set own ones
+        xStream.addPermission(NoTypePermission.NONE);
+        // allow some basics
+        xStream.addPermission(NullPermission.NULL);
+        xStream.addPermission(PrimitiveTypePermission.PRIMITIVES);
+        xStream.allowTypeHierarchy(Collection.class);
+        // allow any type from the same package
+        xStream.allowTypesByWildcard(new String[] {
+            "fr.cnes.sonar.plugins.hadolint.**"
+        });
+
         xStream.processAnnotations(cls);
+
         return xStream.fromXML(file);
     }
 


### PR DESCRIPTION
## Proposed changes
Configure XStream security feature to avoid a security warning in SonarQube logs.
Explicitly define the list of XStream Converters needed, to avoid the ones that generates warnings in Java 9+.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #4 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lequal/sonar-hadolint-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/lequal/sonar-hadolint-plugin/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
