### PR TITLE
Add AS in Dockerfile keywords list

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugins/hadolint/settings/HadolintPluginProperties.java
+++ b/src/main/java/fr/cnes/sonar/plugins/hadolint/settings/HadolintPluginProperties.java
@@ -42,9 +42,9 @@ public class HadolintPluginProperties {
     public static final String HADOLINT_NAME = "Hadolint";
 
     /**
-     * List of know keywords in Dockerfiles
+     * List of known keywords in Dockerfiles
      */
-    private static final List<String> DOCKERFILE_KEYWORDS = Arrays.asList("FROM", "RUN", "CMD", "LABEL", "MAINTAINER",
+    private static final List<String> DOCKERFILE_KEYWORDS = Arrays.asList("FROM", "AS", "RUN", "CMD", "LABEL", "MAINTAINER",
             "EXPOSE", "ENV", "ADD", "COPY", "ENTRYPOINT", "VOLUME", "USER", "WORKDIR", "ARG", "ONBUILD", "STOPSIGNAL",
             "HEALTHCHECK", "SHELL");
 

--- a/src/test/java/fr/cnes/sonar/plugins/hadolint/settings/HadolintPluginPropertiesTest.java
+++ b/src/test/java/fr/cnes/sonar/plugins/hadolint/settings/HadolintPluginPropertiesTest.java
@@ -45,7 +45,7 @@ public class HadolintPluginPropertiesTest {
     @Test
     public void testGetDockerfileKeywords() {
         List<String> keywords = HadolintPluginProperties.getDockerfileKeywords();
-        assertEquals(18, keywords.size());
+        assertEquals(19, keywords.size());
     }
 
     @Test(expected = InvocationTargetException.class)


### PR DESCRIPTION
## Proposed changes
Add the "AS" string in the Dockerfile keyword list.

## Types of changes

What types of changes does your code introduce to this plugin?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #13 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lequal/sonar-hadolint-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/lequal/sonar-hadolint-plugin/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is a silly fix, as the Lexer may find Dockerfile keywords inside common code, like a variable name.
