### PR TITLE
Fix error when report is absolute path

### DIFF
--- a/src/main/java/fr/cnes/sonar/plugins/hadolint/check/HadolintSensor.java
+++ b/src/main/java/fr/cnes/sonar/plugins/hadolint/check/HadolintSensor.java
@@ -41,6 +41,8 @@ import org.sonar.api.utils.log.Loggers;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -205,9 +207,20 @@ public class HadolintSensor implements Sensor {
         // Check if each path is known by the file system and add it to the processable
         // path list,
         // otherwise print a warning and ignore this result file.
+        Path reportPath;
+        File report;
+        
         for (String path : pathArray) {
-            final File file = new File(fileSystem.baseDir(), path);
-            if (file.exists() && file.isFile()) {
+            // Check if the path is absolute and create the appropriate File object
+            reportPath = Paths.get(path, "");
+
+            if(reportPath.isAbsolute()) {
+                report = new File(path);
+            } else {
+                report = new File(fileSystem.baseDir(), path);
+            }
+
+            if (report.exists() && report.isFile()) {
                 result.add(path);
                 LOGGER.info(String.format("Result file %s has been found and will be processed.", path));
             } else {

--- a/src/test/java/fr/cnes/sonar/plugins/hadolint/check/HadolintSensorTest.java
+++ b/src/test/java/fr/cnes/sonar/plugins/hadolint/check/HadolintSensorTest.java
@@ -133,7 +133,7 @@ public class HadolintSensorTest {
     }
 
     @Test
-	public void testNormalWork() {
+	public void testRelativePath() {
         // Path for reports and Dockerfiles are correct
         MapSettings settings = new MapSettings();
         settings.setProperty(PROPERTY_REPORT_PATH, REPORT_PATH);
@@ -151,12 +151,26 @@ public class HadolintSensorTest {
         
         // Check we get the expected issue
         assertEquals(1, context.allIssues().size());
+    }
 
-        // Do the same test with report absolute path
-        File absolutePathReport = new File(REPORT_PATH);
-        settings.setProperty(PROPERTY_REPORT_PATH, absolutePathReport.getAbsolutePath());
+    @Test
+	public void testAbsolutePath() {
+        // Path for reports and Dockerfiles are correct
+        MapSettings settings = new MapSettings();
+        settings.setProperty(PROPERTY_REPORT_PATH, context.fileSystem().resolvePath(REPORT_PATH).getAbsolutePath());
+        settings.setProperty(PROPERTY_DOCKERFILE_PATTERNS, DOCKERFILE_PATH);
         context.setSettings(settings);
+
+        // Simulate active rule
+        ActiveRules rules = Mockito.mock(ActiveRules.class);
+        ActiveRule rule = Mockito.mock(ActiveRule.class);
+        Mockito.when(rules.find(RuleKey.of(DockerfileLanguage.KEY, "DL3000"))).thenReturn(rule);
+        context.setActiveRules(rules);
+
+		final HadolintSensor sensor = new HadolintSensor();
         sensor.execute(context);
+
+        // Check we get the expected issue
         assertEquals(1, context.allIssues().size());
     }
 

--- a/src/test/java/fr/cnes/sonar/plugins/hadolint/check/HadolintSensorTest.java
+++ b/src/test/java/fr/cnes/sonar/plugins/hadolint/check/HadolintSensorTest.java
@@ -151,6 +151,13 @@ public class HadolintSensorTest {
         
         // Check we get the expected issue
         assertEquals(1, context.allIssues().size());
+
+        // Do the same test with report absolute path
+        File absolutePathReport = new File(REPORT_PATH);
+        settings.setProperty(PROPERTY_REPORT_PATH, absolutePathReport.getAbsolutePath());
+        context.setSettings(settings);
+        sensor.execute(context);
+        assertEquals(1, context.allIssues().size());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

When using an absolute path for hadolint reports, the plugin won't find them because its root search path is the current directory, so only relative paths would work.
Of course, this should work with absolute path.

## Types of changes

What types of changes does your code introduce to this plugin?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close #27 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lequal/sonar-hadolint-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I agree with the [CODE OF CONDUCT](https://github.com/lequal/sonar-hadolint-plugin/blob/master/CONTRIBUTING.md)
- [x] Lint and unit tests pass locally with my changes
- [x] SonarCloud and Travis CI tests pass with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
